### PR TITLE
Curl mbedTLS fix

### DIFF
--- a/ports/curl/0005_mbedtls.patch
+++ b/ports/curl/0005_mbedtls.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/vtls/mbedtls.c b/lib/vtls/mbedtls.c
+index d7759dc84..c862f744a 100644
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -577,6 +577,8 @@ mbed_connect_step2(struct connectdata *conn,
+ 
+   ret = mbedtls_ssl_get_verify_result(&BACKEND->ssl);
+ 
++  if(!SSL_CONN_CONFIG(verifyhost))
++    ret &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;   /* Ignore hostname errors */
+   if(ret && SSL_CONN_CONFIG(verifypeer)) {
+     if(ret & MBEDTLS_X509_BADCERT_EXPIRED)
+       failf(data, "Cert verify failed: BADCERT_EXPIRED");

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         0002_fix_uwp.patch
         0003_fix_libraries.patch
         0004_nghttp2_staticlib.patch
+        0005_mbedtls.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
Needed until such time as `vcpkg` is getting a version of Curl with this fix.