### PR TITLE
avro-cpp - Adding support for Avro CPP library builds.

### DIFF
--- a/ports/avro-cpp/CONTROL
+++ b/ports/avro-cpp/CONTROL
@@ -1,0 +1,4 @@
+Source: avro-cpp
+Version: 1.9.0-SNAPSHOT
+Description: Apache Avro is a data serialization system
+Build-Depends: boost-crc, boost-filesystem, boost-format, boost-iostreams, boost-program-options, boost-ptr-container, boost-random, boost-regex, boost-system, boost-test

--- a/ports/avro-cpp/avro-cpp.patch
+++ b/ports/avro-cpp/avro-cpp.patch
@@ -1,0 +1,35 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 67892d6f..7ad4bde1 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -47,12 +47,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+     add_definitions (/EHa)
+     add_definitions (
+         -DNOMINMAX
+-        -DBOOST_REGEX_DYN_LINK
+-        -DBOOST_FILESYSTEM_DYN_LINK
+-        -DBOOST_SYSTEM_DYN_LINK
+-        -DBOOST_IOSTREAMS_DYN_LINK
+-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+-        -DBOOST_ALL_NO_LIB)
++	-DBOOST_ALL_DYN_LINK)
+ else()
+     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ endif()
+@@ -150,6 +145,7 @@ gen (tree2 tr2)
+ gen (crossref cr)
+ gen (primitivetypes pt)
+ 
++set(VCPKG_APPLOCAL_DEPS ON)
+ add_executable (avrogencpp impl/avrogencpp.cc)
+ target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+ 
+@@ -189,7 +185,7 @@ include (CPack)
+ install (TARGETS avrocpp avrocpp_s
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    RUNTIME DESTINATION bin)
+ 
+ install (TARGETS avrogencpp RUNTIME DESTINATION bin)
+ 

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -1,0 +1,44 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO rosenqui/avro
+  REF dc98fd3a5e0a342fc1471a703ac9abe746c55118
+  SHA512 22d84717b995e6ff30fc7f8756ca4542410c0ac1f8ca0c9929495c81555ce28daa359b20fa4ed9bc85f77c8609b7ee5aecb10d8bc04123c82506d13226f5e314
+  HEAD_REF master
+)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/avro-cpp.patch)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/lang/c++
+    PREFER_NINJA
+    OPTIONS
+        -DCMAKE_DEBUG_POSTFIX=_d
+)
+
+vcpkg_install_cmake()
+
+file(INSTALL ${SOURCE_PATH}/lang/c++/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/avro-cpp RENAME copyright)
+
+vcpkg_copy_pdbs()
+
+# Install EXEs to the tools folder
+file(GLOB EXES
+        ${CURRENT_PACKAGES_DIR}/bin/avrogencpp.exe
+    )
+file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/avro-cpp)
+# Tools require dlls
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/avro-cpp)
+# Remove the EXEs from the bin folders
+file(GLOB TO_REMOVE
+        ${CURRENT_PACKAGES_DIR}/bin/avrogencpp.exe
+        ${CURRENT_PACKAGES_DIR}/debug/bin/avrogencpp.exe)
+file(REMOVE ${TO_REMOVE})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/avrocpp_s.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/avrocpp_s_d.lib)


### PR DESCRIPTION
This still pulls the Avro distribution from `rosenqui/avro` - that's needed until such time as Avro merges my fixes and has a build we can use.